### PR TITLE
Simplify controllers by removing redundant checks

### DIFF
--- a/Dsw2025Tpi.Api/Controllers/OrdersController.cs
+++ b/Dsw2025Tpi.Api/Controllers/OrdersController.cs
@@ -1,6 +1,5 @@
 ﻿using Dsw2025Tpi.Application.Dtos.Requests;
 using Dsw2025Tpi.Application.Dtos.Responses;
-using Dsw2025Tpi.Application.Exceptions;
 using Dsw2025Tpi.Application.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
@@ -12,7 +11,7 @@ namespace Dsw2025Tpi.Api.Controllers;
 [Route("api/orders")]
 public class OrdersController : ControllerBase
 {
-    private readonly IOrderService? _orderService;
+    private readonly IOrderService _orderService;
     public OrdersController(IOrderService orderService)
     {
         _orderService = orderService;
@@ -24,7 +23,7 @@ public class OrdersController : ControllerBase
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<OrderResponse>> CreateOrder([FromBody] OrderRequest request)
     {
-        var createdOrder = await _orderService!.CreateAsync(request);
+        var createdOrder = await _orderService.CreateAsync(request);
 
         return CreatedAtAction(
             nameof(GetById),
@@ -44,7 +43,7 @@ public class OrdersController : ControllerBase
     [FromQuery] int pageNumber = 1,
     [FromQuery] int pageSize = 10)
     {
-        var orders = await _orderService!.GetAllAsync(status, customerId, pageNumber, pageSize);
+        var orders = await _orderService.GetAllAsync(status, customerId, pageNumber, pageSize);
         return Ok(orders);
     }
 
@@ -53,10 +52,7 @@ public class OrdersController : ControllerBase
     [Authorize(Roles = "Administrador, Cliente")]
     public async Task<IActionResult> GetById(Guid id)
     {
-        var result = await _orderService!.GetByIdAsync(id);
-        if (result is null)
-            return NotFound(new { error = "Orden no encontrada." });
-
+        var result = await _orderService.GetByIdAsync(id);
         return Ok(result);
     }
 
@@ -64,10 +60,7 @@ public class OrdersController : ControllerBase
     [Authorize(Roles = "Administrador")]
     public async Task<IActionResult> UpdateStatus(Guid id, [FromBody] UpdateOrderStatusRequest request)
     {
-        var updatedOrder = await _orderService!.UpdateStatusAsync(id, request.NewStatus);
-        if (updatedOrder is null)
-            return NotFound(new { error = "Orden no encontrada para actualizar estado." });
-
+        var updatedOrder = await _orderService.UpdateStatusAsync(id, request.NewStatus);
         return Ok(updatedOrder);
     }
 

--- a/Dsw2025Tpi.Api/Controllers/ProductsController.cs
+++ b/Dsw2025Tpi.Api/Controllers/ProductsController.cs
@@ -24,9 +24,6 @@ public class ProductsController : ControllerBase
     public async Task<IActionResult> Create([FromBody] ProductRequest request)
     {
         var created = await _productService.CreateAsync(request);
-        if (created is null)
-            return BadRequest(new { error = "Error al crear el producto. Verifique los datos." });
-
         return CreatedAtAction(nameof(GetById), new { id = created.Id }, created); // 201 Created
     }
 


### PR DESCRIPTION
## Summary
- remove redundant null-forgiveness and manual not found responses in OrdersController
- streamline product creation action to rely on service-level validation

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dabf083eb8832799712919c121b3a1